### PR TITLE
yarn のための設定を追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/.yarn/releases/** binary
+/.yarn/plugins/** binary

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,12 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# yarn (cf. https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored)
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions


### PR DESCRIPTION
#8 
でパッケージ管理を yarn に変更しましたが、
事前にやっておくべき設定を新たに加えておきました。

### .gitignore
https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
を参考に適用しました。

![image](https://user-images.githubusercontent.com/17216462/154824615-fe51241b-238f-4c63-914c-f039c753302a.png)

### .gitattributes
同じページにこのような note が書かれており、せっかくなのでこちらも倣っておきました。

![image](https://user-images.githubusercontent.com/17216462/154824627-4266995e-7ee2-4ce8-9819-52a650a609d2.png)

.yarn/releases/yarn-1.22.17.cjs

はyarn のバージョン固定のためにコミットされたバイナリファイルで、
gitの差分で面倒なことにならないようにできるんだと思います。