### PR TITLE
user情報取得処理にエラーハンドリングを追加

### DIFF
--- a/src/components/Authentication.tsx
+++ b/src/components/Authentication.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect, useState, VFC } from "react";
-import { User } from "@supabase/supabase-js";
+import { Session, User, ApiError } from "@supabase/gotrue-js";
 import { Auth } from "@supabase/ui";
 import { AuthenticationPresenter } from "./AuthenticationPresenter";
 import { supabase } from "../../utils/supabaseClient";
@@ -13,17 +13,30 @@ export const Authentication: VFC<AuthenticationProps> = ({ children }) => {
   const { session } = Auth.useUser();
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<ApiError | null>(null);
+
+  const getUserBySession = async (session: Session) => {
+    const { user, error } = await supabase.auth.api.getUser(
+      session.access_token
+    );
+    if (error) {
+      setError(error);
+      console.error(error.message, error.status);
+    }
+    if (user) setUser(user);
+  };
 
   useEffect(() => {
     if (!user && session) {
-      (async () => {
-        const response = await supabase.auth.api.getUser(session.access_token);
-        setUser(response.user);
-      })();
+      getUserBySession(session);
     } else {
       setIsLoading(false);
     }
   }, [user, session]);
+
+  if (error) {
+    return <Loader />; // TODO: should be replaced with `Error Boundary`
+  }
 
   if (isLoading) {
     return <Loader />;


### PR DESCRIPTION
# やったこと

- user情報取得処理にエラーハンドリングを追加しました

# やらないこと

- エラーが発生したときのフォールバック用コンポーネントの実装（通称：Error Boundary）

# できるようになること

## ユーザ目線

- とくに変わりありません。

## 開発目線

- ユーザ情報取得APIから返されたエラーの内容が console から確認できるようになります。

# 動作確認

## エラーハンドリングの検知

### 何を

APIがエラーを返したとき、その内容を console に表示できる

### どのように

supabase のapi (getUser) でエラーを意図的に起こす方法が現状思い当たらないので、
動作確認がちゃんとできていません 🙏 

ただ、起きたときのセーフティとしていれたいお気持ちがあります。
実装の不備があればその都度修正します。。。

### Screenshot / Video

文字で伝わりにくい、「どのように」を文面にするのが大変、レビュアへ補足したい、などのときにアップロードしてください。

# レビュワーへの参考情報

-
