### PR TITLE
user情報取得処理をカスタムフック化

### DIFF
--- a/src/components/Authentication.tsx
+++ b/src/components/Authentication.tsx
@@ -4,6 +4,7 @@ import { Auth } from "@supabase/ui";
 import { AuthenticationPresenter } from "./AuthenticationPresenter";
 import { supabase } from "../../utils/supabaseClient";
 import { Loader } from "./Loader";
+import useFetchUser from "../hooks/useFetchUser";
 
 export type AuthenticationProps = {
   children: ReactNode;
@@ -11,28 +12,7 @@ export type AuthenticationProps = {
 
 export const Authentication: VFC<AuthenticationProps> = ({ children }) => {
   const { session } = Auth.useUser();
-  const [user, setUser] = useState<User | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [error, setError] = useState<ApiError | null>(null);
-
-  const getUserBySession = async (session: Session) => {
-    const { user, error } = await supabase.auth.api.getUser(
-      session.access_token
-    );
-    if (error) {
-      setError(error);
-      console.error(error.message, error.status);
-    }
-    if (user) setUser(user);
-  };
-
-  useEffect(() => {
-    if (!user && session) {
-      getUserBySession(session);
-    } else {
-      setIsLoading(false);
-    }
-  }, [user, session]);
+  const { user, error, isLoading } = useFetchUser(session);
 
   if (error) {
     return <Loader />; // TODO: should be replaced with `Error Boundary`

--- a/src/components/Authentication.tsx
+++ b/src/components/Authentication.tsx
@@ -1,5 +1,4 @@
-import { ReactNode, useEffect, useState, VFC } from "react";
-import { Session, User, ApiError } from "@supabase/gotrue-js";
+import { ReactNode, VFC } from "react";
 import { Auth } from "@supabase/ui";
 import { AuthenticationPresenter } from "./AuthenticationPresenter";
 import { supabase } from "../../utils/supabaseClient";

--- a/src/components/Authentication.tsx
+++ b/src/components/Authentication.tsx
@@ -21,10 +21,6 @@ export const Authentication: VFC<AuthenticationProps> = ({ children }) => {
     return <Loader />;
   }
 
-  if (!session) {
-    return <AuthenticationPresenter supabaseClient={supabase} />;
-  }
-
   return user ? (
     <>{children}</>
   ) : (

--- a/src/hooks/useFetchUser.ts
+++ b/src/hooks/useFetchUser.ts
@@ -7,7 +7,7 @@ const useFetchUser = (session: Session | null) => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<ApiError | null>(null);
 
-  const getUserBySession = async (session: Session) => {
+  const fetchUserBySession = async (session: Session) => {
     const { user, error } = await supabase.auth.api.getUser(
       session.access_token
     );
@@ -20,13 +20,13 @@ const useFetchUser = (session: Session | null) => {
 
   useEffect(() => {
     if (!user && session) {
-      getUserBySession(session);
+      fetchUserBySession(session);
     } else {
       setIsLoading(false);
     }
   }, [user, session]);
 
-  return { user, error, isLoading, getUserBySession };
+  return { user, error, isLoading, fetchUserBySession };
 };
 
 export default useFetchUser;

--- a/src/hooks/useFetchUser.ts
+++ b/src/hooks/useFetchUser.ts
@@ -26,7 +26,7 @@ const useFetchUser = (session: Session | null) => {
     }
   }, [user, session]);
 
-  return { user, error, isLoading, fetchUserBySession };
+  return { user, error, isLoading, refetchUserBySession: fetchUserBySession };
 };
 
 export default useFetchUser;

--- a/src/hooks/useFetchUser.ts
+++ b/src/hooks/useFetchUser.ts
@@ -28,7 +28,7 @@ const useFetchUser = (session: Session | null) => {
     }
   }, [session]);
 
-  return { user, error, isLoading, refetchUserBySession: fetchUserBySession };
+  return { user, error, isLoading };
 };
 
 export default useFetchUser;

--- a/src/hooks/useFetchUser.ts
+++ b/src/hooks/useFetchUser.ts
@@ -16,15 +16,17 @@ const useFetchUser = (session: Session | null) => {
       console.error(error.message, error.status);
     }
     if (user) setUser(user);
+
+    setIsLoading(false);
   };
 
   useEffect(() => {
-    if (!user && session) {
+    if (session) {
       fetchUserBySession(session);
     } else {
       setIsLoading(false);
     }
-  }, [user, session]);
+  }, [session]);
 
   return { user, error, isLoading, refetchUserBySession: fetchUserBySession };
 };

--- a/src/hooks/useFetchUser.ts
+++ b/src/hooks/useFetchUser.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { Session, User, ApiError } from "@supabase/gotrue-js";
+import { supabase } from "../../utils/supabaseClient";
+
+const useFetchUser = (session: Session | null) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<ApiError | null>(null);
+
+  const getUserBySession = async (session: Session) => {
+    const { user, error } = await supabase.auth.api.getUser(
+      session.access_token
+    );
+    if (error) {
+      setError(error);
+      console.error(error.message, error.status);
+    }
+    if (user) setUser(user);
+  };
+
+  useEffect(() => {
+    if (!user && session) {
+      getUserBySession(session);
+    } else {
+      setIsLoading(false);
+    }
+  }, [user, session]);
+
+  return { user, error, isLoading, getUserBySession };
+};
+
+export default useFetchUser;


### PR DESCRIPTION
# やったこと

- Authentication Component のユーザ情報取得のロジックをカスタムフックにしました。

# やらないこと

- とくになし

# できるようになること

## ユーザ目線

- 変化なし

## 開発目線

- hooks にすることで
	- ロジックが再利用可能になる
	- テストしやすい
	- コードの見通しが良くなる

# 動作確認

## 認証処理

### 何を

既存の認証処理の挙動がデグレしていない。

### どのように

ローカル環境で
```
http://localhost:3000
```
にアクセスし、ログイン、セッションの削除を実行して確認

### Screenshot / Video

文字で伝わりにくい、「どのように」を文面にするのが大変、レビュアへ補足したい、などのときにアップロードしてください。

# レビュワーへの参考情報
このあたりを参考にしました。

DIY: Writing custom React Hooks to perform async operations
https://www.ankurkedia.com/blog/custom-hooks

Building custom hooks in React to fetch Data - DEV Community 👩‍💻👨‍💻
https://dev.to/shaedrizwan/building-custom-hooks-in-react-to-fetch-data-4ig6?signin=true