### PR TITLE
都度 supabase のダッシュボードの設定変更をせずに本番環境で認証後リダイレクトを可能にした

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_AUTH_REDIRECT_URL=https://qin-todo.vercel.app

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,11 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,
     "source.fixAll.format": true
+  },
+  "files.associations": {
+    "*.env*": "env"
+  },
+  "[env]": {
+    "editor.formatOnSave": false
   }
 }

--- a/src/components/AuthenticationPresenter.tsx
+++ b/src/components/AuthenticationPresenter.tsx
@@ -12,6 +12,7 @@ export const AuthenticationPresenter: VFC<Props> = ({ supabaseClient }) => {
       onlyThirdPartyProviders={true}
       supabaseClient={supabaseClient}
       providers={["google"]}
+      redirectTo={process.env.NEXT_PUBLIC_AUTH_REDIRECT_URL}
     />
   );
 };


### PR DESCRIPTION
# やったこと

## 本番環境で認証後に正常に認証後のページにリダイレクトできるようにしました。
- なぜ本番で動かなかったのか
	- supabase のダッシュボードの設定 `Site URL` が認証後のリダイレクト先となるが、1つしか設定できない。
	- その設定が規定の設定のまま（開発環境 `localhost` ）となっている。
	- 変更は可能だが、本番環境に設定すると当然、開発環境で実行できなくなってしまう。
	- 開発に支障が生じるため、現状は開発環境を優先に設定していた。
- 解決アプローチ
	- https://github.com/supabase/supabase/discussions/600#discussioncomment-1879317
		- に則りました。
		- 任意のリダイレクト先を `Auth` コンポーネントの `redirectTo` に設定することで実現しています。
			- cf. https://supabase.com/docs/reference/javascript/auth-signin#sign-in-with-redirect
		- その設定は `.env.production` にデフォルトの環境変数として設定しています。
		- （なぜかはわからないが）任意のリダイレクト先（ `Additional Redirect URLs` ）については、複数の許可リスト設定が可能です。
		- この仕組みにより、環境別に認証後のリダイレクト先を設定して飛ばすことが可能になります。

### FYI
なお、開発環境では `.env.local` に同様の設定が必要です。
また、 localhost の別のパスに設定したい場合は supabase のダッシュボードを設定をイジる必要はありません。

## env 系のファイルで prettier が効かないようにしました
ファイル保存のたびに警告がでてうざいからです。

# やらないこと

- preview環境の適用
	- preview環境では `https://qin-todo.vercel.app` のドメインの一部が毎回書き換わります。
	- そのため、 supabase のダッシュボード上で毎回設定が必要になります。
	- 現状、ワイルドカード `*` などによって部分一致による許可設定はできないため、対応が難しそうです。

# できるようになること

## ユーザ目線

- 本番環境で認証→ページの表示ができる。

## 開発目線

- supabase ダッシュボードの設定の書き換えなしに本番環境と開発環境の実行環境で認証→ページの表示ができる。

# 動作確認

## リダイレクト先の設定ができる

### 何を

`.env.local` に任意のURLを設定し、認証を実行するとそのURLに飛ぶことができる。

### どのように

認証のページ
```
htttp://localhost:3000
```
にアクセスし、認証を実行する。

### Screenshot / Video

#### supbase ダッシュボードの設定
`Additional Redirect URLs` に `.env.production` と同じURLを追加しています。
なお、カンマ区切り（スペースなし）で複数の指定が可能です。
cf. https://app.supabase.io/project/ikgbrzzcdnnfwwqcpbwz/auth/settings

![SCR-20220323-oix](https://user-images.githubusercontent.com/17216462/159658122-0f25490e-062a-43c8-a4eb-ff55a00e6fc1.png)

#### envの prettier の警告
こういった警告がでるため、オフにしています。

<img width="1680" alt="スクリーンショット 2022-03-23 17 18 03" src="https://user-images.githubusercontent.com/17216462/159657132-d8a97800-969a-42fe-8682-729527373c4f.png">


# レビュワーへの参考情報

### 認証後のリダイレクトの仕組み
よくわからなかったらこちらも参照してください。
supabase の CTO の発言なので信用できるかと思います。

https://github.com/supabase/supabase/discussions/600#discussioncomment-810640


### env を off にする仕組み
How To Disable VS Code ‘formatOnSave’ For Specific File Extensions? | by Zulhilmi Zainudin | Medium
https://medium.com/@zulhhandyplast/how-to-disable-vs-code-formatonsave-for-specific-file-extensions-c60e8f254243
