### PR TITLE
next/image 起因で発生している種々の問題を解決

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -20,6 +20,7 @@ export const Header = (props: Props) => {
             alt="Qintodoサムネイル"
             width="112px"
             height="24px"
+            layout="fixed"
           />
         </a>
       </Link>
@@ -31,6 +32,7 @@ export const Header = (props: Props) => {
               alt="プロフィール画像"
               width="36px"
               height="36px"
+              layout="fixed"
             />
           </button>
         }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -47,6 +47,7 @@ export const Header = (props: Props) => {
                 alt="設定"
                 width="22px"
                 height="22px"
+                layout="fixed"
               />
             </div>
           }
@@ -63,6 +64,7 @@ export const Header = (props: Props) => {
                 alt="ログアウト"
                 width="22px"
                 height="22px"
+                layout="fixed"
               />
             </div>
           }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -14,7 +14,7 @@ export const Header = (props: Props) => {
   return (
     <header className="flex justify-between items-center px-[196px] h-20 w-full bg-white">
       <Link href="/">
-        <a>
+        <a className="next-image-space-removal-wrapper">
           <Image
             src="/QinToDo.svg"
             alt="Qintodoサムネイル"
@@ -26,7 +26,7 @@ export const Header = (props: Props) => {
       </Link>
       <Menu
         control={
-          <button>
+          <div className="next-image-space-removal-wrapper">
             <Image
               src={props.user.image}
               alt="プロフィール画像"
@@ -35,7 +35,7 @@ export const Header = (props: Props) => {
               layout="fixed"
               objectFit="contain"
             />
-          </button>
+          </div>
         }
       >
         <Menu.Item

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -38,7 +38,14 @@ export const Header = (props: Props) => {
         <Menu.Item
           className={className}
           icon={
-            <Image src="/settings.svg" alt="設定" width="22px" height="22px" />
+            <div className="next-image-space-removal-wrapper">
+              <Image
+                src="/settings.svg"
+                alt="設定"
+                width="22px"
+                height="22px"
+              />
+            </div>
           }
         >
           設定
@@ -47,12 +54,14 @@ export const Header = (props: Props) => {
           className={className}
           color="red"
           icon={
-            <Image
-              src="/logout.svg"
-              alt="ログアウト"
-              width="22px"
-              height="22px"
-            />
+            <div className="next-image-space-removal-wrapper">
+              <Image
+                src="/logout.svg"
+                alt="ログアウト"
+                width="22px"
+                height="22px"
+              />
+            </div>
           }
         >
           ログアウト

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -33,6 +33,7 @@ export const Header = (props: Props) => {
               width="36px"
               height="36px"
               layout="fixed"
+              objectFit="contain"
             />
           </button>
         }

--- a/src/components/TaskCard/index.tsx
+++ b/src/components/TaskCard/index.tsx
@@ -1,6 +1,4 @@
 import type { VFC } from "react";
-import Image from "next/image";
-
 import type { ScheduleType } from "../TaskHeader";
 import { TaskHeader } from "../TaskHeader";
 import { TaskForm } from "../TaskForm";

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -35,7 +35,7 @@ export const TaskForm: VFC = () => {
     <form onSubmit={handleSubmitToAddTask}>
       <TaskList tasks={tasks} setTasks={setTasks} />
       <div className="flex py-2 gap-x-2">
-        <div>
+        <div className="next-image-space-removal-wrapper">
           <Image
             src="/PlusIcon.svg"
             alt="+"

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -32,7 +32,7 @@ export const TaskForm: VFC = () => {
   };
 
   return (
-    <form className="" onSubmit={handleSubmitToAddTask}>
+    <form onSubmit={handleSubmitToAddTask}>
       <TaskList tasks={tasks} setTasks={setTasks} />
       <div className="flex py-2 gap-x-2">
         <div>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -58,7 +58,7 @@ export const TaskItem: VFC<TaskItemProps> = ({
         </p>
       </label>
 
-      <div className="invisible group-hover:visible">
+      <div className="next-image-space-removal-wrapper invisible group-hover:visible">
         <Image
           src="/duplicateTask.svg"
           alt="duplicateTask"
@@ -69,7 +69,7 @@ export const TaskItem: VFC<TaskItemProps> = ({
         />
       </div>
 
-      <div className="invisible group-hover:visible">
+      <div className="next-image-space-removal-wrapper invisible group-hover:visible">
         <Image
           src="/deleteTask.svg"
           alt="deleteTask"

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -49,13 +49,13 @@ export const TaskItem: VFC<TaskItemProps> = ({
           checked={task.isDone}
           onChange={toggleIsDone}
         />
-        {task.isDone ? (
-          <p className="text-[#C2C6D2] line-through break-all">
-            {task.content}
-          </p>
-        ) : (
-          <p className="break-all">{task.content}</p>
-        )}
+        <p
+          className={`break-all ${
+            task.isDone ? "line-through text-[#C2C6D2]" : ""
+          }`}
+        >
+          {task.content}
+        </p>
       </label>
 
       <div className="hidden group-hover:block">

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -58,7 +58,7 @@ export const TaskItem: VFC<TaskItemProps> = ({
         </p>
       </label>
 
-      <div className="hidden group-hover:block">
+      <div className="invisible group-hover:visible">
         <Image
           src="/duplicateTask.svg"
           alt="duplicateTask"
@@ -69,7 +69,7 @@ export const TaskItem: VFC<TaskItemProps> = ({
         />
       </div>
 
-      <div className="hidden group-hover:block">
+      <div className="invisible group-hover:visible">
         <Image
           src="/deleteTask.svg"
           alt="deleteTask"

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -28,7 +28,7 @@ export const TaskItem: VFC<TaskItemProps> = ({
   return (
     <div className="flex items-center gap-x-2 group">
       <label className="flex items-center gap-x-2 mr-auto">
-        <div>
+        <div className="next-image-space-removal-wrapper">
           <Image
             src={`${
               task.isDone

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,3 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .next-image-space-removal-wrapper {
+    letter-spacing: 0;
+    word-spacing: 0;
+    font-size: 0;
+  }
+}


### PR DESCRIPTION
# やったこと
next/image コンポーネントを用いた際に発生していた種々の問題を解決しました。
具体的には以下の通り。（詳細はコミット参照のこと。）

- ヘッダーのプロフィール画像の縦横比が保てていない問題を解決しました
- ヘッダーのロゴ、プロフィール画像が画面幅が小さいときに縮小されてしまう問題を解決しました
- next/image をブロック要素の子要素にした場合に余計な余白が生まれてしまう問題を解決しました
	- nextプロジェクトで既知となっている不具合のワークアラウンドです。
		- cf. https://github.com/vercel/next.js/issues/18915
- タスクをホバーして複製・削除ボタンが表示される際のテキストのサイズが可変してしまう問題を解決しました
- ...etc（ささいなリファクタリング）

# やらないこと

- 上記対応の範囲外のこと

# できるようになること

## ユーザ目線

- ログイン後にプロフィール画像を設定したときにその画像の比率が保って表示されるようになる
- アイコンなどの画像の位置ずれが気にならなくなる

## 開発目線

- next/image を使うときに `.next-image-space-removal-wrapper` class でラップすることで余白を作らないように実装できる

# 動作確認

## タイトル

next/image を使った既知の問題の解消

### 何を

- DOMとしてレンダリングした際に余計な余白が消え、水平の表示位置が揃って表示される
- ヘッダーについて
	- 画面幅に応じて画像の縮尺が変更されない
	- プロフィール画像の画像の比率が変更されない

### どのように

```
http://localhost:3000/
```
で各種操作を行う


## タイトル

タスクをマウスホバーした時の挙動

### 何を

- テキストの表示幅が可変しない

### どのように

```
http://localhost:3000/
```
で各種操作を行う


### Screenshot / Video

#### next/image を使った既知の問題の解消

before:

![fix_next_image_issues_BEFORE](https://user-images.githubusercontent.com/17216462/160285742-62e32686-a74c-4046-ad8d-3907990429ea.png)

after:
画像の余白により発生していた位置ずれが修正されています。

![fix_next_image_issues_AFTER](https://user-images.githubusercontent.com/17216462/160285747-45952631-d9be-4ce1-ab0f-9e3d3d47b12d.png)

#### タスクをマウスホバーした時に問題だった挙動
この挙動を最初から幅を確保するようにして直しました

https://user-images.githubusercontent.com/17216462/160285720-73076ff6-e36f-4566-b61a-77d50aaa7221.mov


# レビュワーへの参考情報

next/image の解決アプローチは以下を参照していただけるとわかるかと思います。
- https://github.com/vercel/next.js/issues/18911#issuecomment-723362202
- https://www.codegrid.net/articles/inline-layout-1/

ちなみに、 next/image の使い方はこのへんがわかりやすいです

https://zenn.dev/nbr41to/articles/365e8105efa448