### PR TITLE
タスクリストにおける個々のタスク編集を可能にした

### DIFF
--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -9,7 +9,7 @@ export const Main: VFC = () => {
       <div className="flex">
         {Object.values(SCHEDULE_LIST).map((schedule) => {
           return (
-            <div className="p-6 w-1/3" key={schedule}>
+            <div className="p-6 w-1/3 min-w-max" key={schedule}>
               <TaskCard schedule={schedule} />
             </div>
           );

--- a/src/components/TaskCard/index.tsx
+++ b/src/components/TaskCard/index.tsx
@@ -13,9 +13,7 @@ export const TaskCard: VFC<Props> = ({ schedule }) => {
       <div className="pb-4">
         <TaskHeader schedule={schedule} />
       </div>
-      <div className="max-w-[65%]">
-        <TaskForm />
-      </div>
+      <TaskForm />
     </>
   );
 };

--- a/src/components/TaskCard/index.tsx
+++ b/src/components/TaskCard/index.tsx
@@ -13,7 +13,7 @@ export const TaskCard: VFC<Props> = ({ schedule }) => {
       <div className="pb-4">
         <TaskHeader schedule={schedule} />
       </div>
-      <div className="max-w-[50%]">
+      <div className="max-w-[65%]">
         <TaskForm />
       </div>
     </>

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -60,7 +60,7 @@ export const TaskForm: VFC = () => {
             type="text"
             placeholder="タスクを追加する"
             {...taskForm.getInputProps("content")}
-            className="outline-none h-6 placeholder:text-[#C2C6D2]"
+            className="w-full outline-none h-6 placeholder:text-[#C2C6D2]"
           />
         </div>
       </form>

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -36,7 +36,7 @@ export const TaskForm: VFC = () => {
   };
 
   return (
-    <>
+    <div className="w-max">
       <form onSubmit={taskListForm.onSubmit(handleSubmitToEditTask)}>
         <TaskList
           tasks={taskListForm.values.tasks}
@@ -64,6 +64,6 @@ export const TaskForm: VFC = () => {
           />
         </div>
       </form>
-    </>
+    </div>
   );
 };

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -31,9 +31,13 @@ export const TaskForm: VFC = () => {
     taskForm.reset();
   };
 
+  const handleSubmitToEditTask = ({ tasks }: TaskListFormValues) => {
+    console.table(tasks);
+  };
+
   return (
     <>
-      <form>
+      <form onSubmit={taskListForm.onSubmit(handleSubmitToEditTask)}>
         <TaskList
           tasks={taskListForm.values.tasks}
           taskListForm={taskListForm}

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -41,6 +41,7 @@ export const TaskForm: VFC = () => {
         <TaskList
           tasks={taskListForm.values.tasks}
           taskListForm={taskListForm}
+          handleSubmitToEditTask={handleSubmitToEditTask}
         />
       </form>
 

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -58,10 +58,10 @@ export const TaskForm: VFC = () => {
           </div>
 
           <input
+            className="w-full outline-none h-6 placeholder:text-[#C2C6D2]"
             type="text"
             placeholder="タスクを追加する"
             {...taskForm.getInputProps("content")}
-            className="w-full outline-none h-6 placeholder:text-[#C2C6D2]"
           />
         </div>
       </form>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -56,7 +56,7 @@ export const TaskItem: VFC<TaskItemProps> = ({ task, index, taskListForm }) => {
       <input
         type="text"
         {...taskListForm.getListInputProps("tasks", index, "content")}
-        className={`w-full break-all ${
+        className={`w-full outline-none break-all ${
           task.isDone ? "line-through text-[#C2C6D2]" : ""
         }`}
       />

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -51,14 +51,15 @@ export const TaskItem: VFC<TaskItemProps> = ({ task, index, taskListForm }) => {
             type: "checkbox",
           })}
         />
-        <p
-          className={`break-all ${
-            task.isDone ? "line-through text-[#C2C6D2]" : ""
-          }`}
-        >
-          {task.content}
-        </p>
       </label>
+
+      <input
+        type="text"
+        {...taskListForm.getListInputProps("tasks", index, "content")}
+        className={`w-full break-all ${
+          task.isDone ? "line-through text-[#C2C6D2]" : ""
+        }`}
+      />
 
       <div className="next-image-space-removal-wrapper invisible group-hover:visible">
         <Image
@@ -81,6 +82,8 @@ export const TaskItem: VFC<TaskItemProps> = ({ task, index, taskListForm }) => {
           onClick={handleClickToDeleteTask}
         />
       </div>
+
+      <button className="invisible" />
     </div>
   );
 };

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -11,9 +11,15 @@ type TaskItemProps = {
   taskListForm: UseFormReturnType<{
     tasks: FormList<Task>;
   }>;
+  handleSubmitToEditTask: ({ tasks }: { tasks: FormList<Task> }) => void;
 };
 
-export const TaskItem: VFC<TaskItemProps> = ({ task, index, taskListForm }) => {
+export const TaskItem: VFC<TaskItemProps> = ({
+  task,
+  index,
+  taskListForm,
+  handleSubmitToEditTask,
+}) => {
   const handleClickToDuplicateTask: MouseEventHandler<
     HTMLImageElement
   > = () => {
@@ -55,6 +61,7 @@ export const TaskItem: VFC<TaskItemProps> = ({ task, index, taskListForm }) => {
 
       <input
         type="text"
+        onBlur={taskListForm.onSubmit(handleSubmitToEditTask)}
         {...taskListForm.getListInputProps("tasks", index, "content")}
         className={`w-full outline-none break-all ${
           task.isDone ? "line-through text-[#C2C6D2]" : ""

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -60,12 +60,12 @@ export const TaskItem: VFC<TaskItemProps> = ({
       </label>
 
       <input
-        type="text"
-        onBlur={taskListForm.onSubmit(handleSubmitToEditTask)}
-        {...taskListForm.getListInputProps("tasks", index, "content")}
         className={`w-full outline-none break-all ${
           task.isDone ? "line-through text-[#C2C6D2]" : ""
         }`}
+        type="text"
+        onBlur={taskListForm.onSubmit(handleSubmitToEditTask)}
+        {...taskListForm.getListInputProps("tasks", index, "content")}
       />
 
       <div className="next-image-space-removal-wrapper invisible group-hover:visible">

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -4,14 +4,14 @@ import { VFC } from "react";
 import { Task } from "../types/task";
 import { TaskItem } from "./TaskItem";
 
-type TaskLlistProps = {
+type TaskListProps = {
   tasks: Task[];
   taskListForm: UseFormReturnType<{
     tasks: FormList<Task>;
   }>;
 };
 
-export const TaskList: VFC<TaskLlistProps> = ({ tasks, taskListForm }) => {
+export const TaskList: VFC<TaskListProps> = ({ tasks, taskListForm }) => {
   return (
     <ul>
       {tasks.map((task, index) => (

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -9,15 +9,25 @@ type TaskListProps = {
   taskListForm: UseFormReturnType<{
     tasks: FormList<Task>;
   }>;
+  handleSubmitToEditTask: ({ tasks }: { tasks: FormList<Task> }) => void;
 };
 
-export const TaskList: VFC<TaskListProps> = ({ tasks, taskListForm }) => {
+export const TaskList: VFC<TaskListProps> = ({
+  tasks,
+  taskListForm,
+  handleSubmitToEditTask,
+}) => {
   return (
     <ul>
       {tasks.map((task, index) => (
         <li key={task.id}>
           <div className="py-2">
-            <TaskItem task={task} index={index} taskListForm={taskListForm} />
+            <TaskItem
+              task={task}
+              index={index}
+              taskListForm={taskListForm}
+              handleSubmitToEditTask={handleSubmitToEditTask}
+            />
           </div>
         </li>
       ))}


### PR DESCRIPTION
# やったこと

- 主目的
	- （フロントにおける）タスクの編集を可能にしました
- 不具合修正
	- 画面の横幅を小さくしたときにタスクリストがつぶれてしまう問題を解決しました
	- （タスクリストの幅はその内容に合わせた幅が最小限保たれるようにしています）
		- cf. 952c31ae85f891f3b250656fc98cdc1e17b07e42

# やらないこと

- 主目的のスコープ外の対応
- タスクリストの複数行表示
	- Figma のデザインでは個々のタスクは複数行で表示可能にする要件があります。
	- しかし、タスクの編集の実装に `<input>` を使用しているがために、複数行表示が難しいです。
	- バックエンドへのリクエストを実装をシンプルにするために `<form>` , `<input>` でフロントエンドの状態変更、およびイベントを管理しています。
	- 複数行表示の要件を優先すると実装が難しくなる可能性を感じているため見送っています。

# できるようになること

## ユーザ目線

- 作成済みタスクの内容を編集できるようになる

## 開発目線

- 内部実装として、編集時のイベントを拾うようにしているため、
- バックエンドにその内容更新を反映するリクエストを投げることができる。
	- （consoleで状態の確認ができるようにしています。）

# 動作確認

## タイトル

タスクの編集

### 何を

- 任意の作成済みのタスクの編集がリアルタイムで状態管理されている。
- また、編集の確定操作（Enter、またはフォーカスをはずす）で送信処理が実行される。

### どのように

- 変更したいタスクをフォーカス（クリック）
	- 内容を変更する
	- Enter、またはフォーカスを外す
	- そのタイミングで、更新されたタスクリストで submit されることを console で確認

### Screenshot / Video

https://user-images.githubusercontent.com/17216462/161410899-64526aaa-d023-4bad-871f-e05a7224078f.mov

## タイトル

画面の横幅を小さくしたときにタスクリストがつぶれてしまう問題を解決

### 何を

画面サイズを小さくしたときにタスクリストがつぶれない

### どのように

画面サイズを小さくする

### Screenshot / Video

https://user-images.githubusercontent.com/17216462/161410771-32dfed40-9863-4444-b4c2-6b6fee02e270.mov



# レビュワーへの参考情報

fit-content, min-content, max-contentの便利な使い方、CSSでコンテンツに依存してサイズを決める | コリス
https://coliss.com/articles/build-websites/operation/css/intrinsic-sizing-in-css.html

javascript - Form with two inputs not submitting? - Stack Overflow
https://stackoverflow.com/questions/28709146/form-with-two-inputs-not-submitting

HTML Standard
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission