### PR TITLE
ドラッグ＆ドロップでタスクの並び替えを可能にした

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@mantine/next": "^4.0.8",
     "@supabase/supabase-js": "^1.31.1",
     "@supabase/ui": "^0.36.4",
+    "@types/uuid": "^8.3.4",
     "next": "12.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "@supabase/ui": "^0.36.4",
     "next": "12.1.0",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next": "12.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "tabler-icons-react": "^1.44.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "jest --watch"
   },
   "dependencies": {
+    "@dnd-kit/core": "^5.0.3",
+    "@dnd-kit/sortable": "^6.0.1",
     "@mantine/core": "^4.0.8",
     "@mantine/form": "^4.1.0",
     "@mantine/hooks": "^4.0.8",

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -43,6 +43,7 @@ export const TaskForm: VFC = () => {
           taskListForm={taskListForm}
           handleSubmitToEditTask={handleSubmitToEditTask}
         />
+        <button className="block invisible" />
       </form>
 
       <form onSubmit={taskForm.onSubmit(handleSubmitToAddTask)}>

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -3,8 +3,9 @@ import { Task } from "../types/task";
 import { TaskList } from "./TaskList";
 import Image from "next/image";
 import { useForm, formList } from "@mantine/form";
+import { v4 as uuidv4 } from "uuid";
 
-export const initializedTask = (id: number): Task => {
+export const initializedTask = (id: string): Task => {
   return { id, content: "", isDone: false };
 };
 
@@ -17,7 +18,7 @@ export const TaskForm: VFC = () => {
   type TaskListFormValues = typeof taskListForm.values;
 
   const taskForm = useForm<Task>({
-    initialValues: initializedTask(Math.random()),
+    initialValues: initializedTask(uuidv4()),
   });
   type TaskFormValues = typeof taskForm.values;
 

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -53,7 +53,7 @@ export const TaskItem: VFC<TaskItemProps> = ({
     >
       <div className="flex items-center gap-x-2 mr-auto">
         <GripVertical
-          className="invisible group-hover:visible absolute -left-6"
+          className="opacity-0 group-hover:opacity-100 absolute -left-6"
           size={24}
           strokeWidth={2}
           color={"#C2C6D2"}

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -85,7 +85,7 @@ export const TaskItem: VFC<TaskItemProps> = ({
       </label>
 
       <input
-        className={`w-full outline-none break-all ${
+        className={`w-full bg-transparent outline-none break-all ${
           task.isDone ? "line-through text-[#C2C6D2]" : ""
         }`}
         type="text"

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -47,13 +47,13 @@ export const TaskItem: VFC<TaskItemProps> = ({
 
   return (
     <div
-      className="flex items-center gap-x-2 group"
+      className="flex items-center gap-x-2 group relative"
       ref={setNodeRef}
       style={style}
     >
       <div className="flex items-center gap-x-2 mr-auto">
         <GripVertical
-          className="invisible group-hover:visible"
+          className="invisible group-hover:visible absolute -left-6"
           size={24}
           strokeWidth={2}
           color={"#C2C6D2"}

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -51,38 +51,40 @@ export const TaskItem: VFC<TaskItemProps> = ({
       ref={setNodeRef}
       style={style}
     >
-      <GripVertical
-        className="invisible group-hover:visible"
-        size={24}
-        strokeWidth={2}
-        color={"#C2C6D2"}
-        {...attributes}
-        {...listeners}
-      />
-
-      <label className="flex items-center gap-x-2 mr-auto">
-        <div className="next-image-space-removal-wrapper">
-          <Image
-            src={`${
-              task.isDone
-                ? "/onCheckedCheckboxIcon.svg"
-                : "/offCheckedCheckboxIcon.svg"
-            }`}
-            alt="checkboxIcon"
-            width={24}
-            height={24}
-            layout="fixed"
-          />
-        </div>
-
-        <input
-          className="absolute opacity-0"
-          type="checkbox"
-          {...taskListForm.getListInputProps("tasks", index, "isDone", {
-            type: "checkbox",
-          })}
+      <div className="flex items-center gap-x-2 mr-auto">
+        <GripVertical
+          className="invisible group-hover:visible"
+          size={24}
+          strokeWidth={2}
+          color={"#C2C6D2"}
+          {...attributes}
+          {...listeners}
         />
-      </label>
+
+        <label>
+          <div className="next-image-space-removal-wrapper">
+            <Image
+              src={`${
+                task.isDone
+                  ? "/onCheckedCheckboxIcon.svg"
+                  : "/offCheckedCheckboxIcon.svg"
+              }`}
+              alt="checkboxIcon"
+              width={24}
+              height={24}
+              layout="fixed"
+            />
+          </div>
+
+          <input
+            className="absolute opacity-0"
+            type="checkbox"
+            {...taskListForm.getListInputProps("tasks", index, "isDone", {
+              type: "checkbox",
+            })}
+          />
+        </label>
+      </div>
 
       <input
         className={`w-full bg-transparent outline-none break-all ${

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -4,6 +4,7 @@ import { Task } from "../types/task";
 import { UseFormReturnType } from "@mantine/form/lib/use-form";
 import { FormList } from "@mantine/form/lib/form-list/form-list";
 import { initializedTask } from "./TaskForm";
+import { v4 as uuidv4 } from "uuid";
 
 type TaskItemProps = {
   task: Task;
@@ -24,7 +25,7 @@ export const TaskItem: VFC<TaskItemProps> = ({
     HTMLImageElement
   > = () => {
     taskListForm.addListItem("tasks", {
-      ...initializedTask(Math.random()),
+      ...initializedTask(uuidv4()),
       content: task.content,
     });
   };

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -89,8 +89,6 @@ export const TaskItem: VFC<TaskItemProps> = ({
           onClick={handleClickToDeleteTask}
         />
       </div>
-
-      <button className="invisible" />
     </div>
   );
 };

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -5,6 +5,9 @@ import { UseFormReturnType } from "@mantine/form/lib/use-form";
 import { FormList } from "@mantine/form/lib/form-list/form-list";
 import { initializedTask } from "./TaskForm";
 import { v4 as uuidv4 } from "uuid";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "tabler-icons-react";
 
 type TaskItemProps = {
   task: Task;
@@ -34,8 +37,29 @@ export const TaskItem: VFC<TaskItemProps> = ({
     taskListForm.removeListItem("tasks", index);
   };
 
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: task.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
   return (
-    <div className="flex items-center gap-x-2 group">
+    <div
+      className="flex items-center gap-x-2 group"
+      ref={setNodeRef}
+      style={style}
+    >
+      <GripVertical
+        className="invisible group-hover:visible"
+        size={24}
+        strokeWidth={2}
+        color={"#C2C6D2"}
+        {...attributes}
+        {...listeners}
+      />
+
       <label className="flex items-center gap-x-2 mr-auto">
         <div className="next-image-space-removal-wrapper">
           <Image

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -23,21 +23,20 @@ export const TaskList: VFC<TaskListProps> = ({
     const { active, over } = event;
 
     if (!over) return;
+    if (active.id === over.id) return;
 
-    if (active.id !== over.id) {
-      const activeIndex = taskListForm.values.tasks.findIndex(
-        (task) => task.id === active.id
-      );
+    const activeIndex = taskListForm.values.tasks.findIndex(
+      (task) => task.id === active.id
+    );
 
-      const overIndex = taskListForm.values.tasks.findIndex(
-        (task) => task.id === over.id
-      );
+    const overIndex = taskListForm.values.tasks.findIndex(
+      (task) => task.id === over.id
+    );
 
-      taskListForm.reorderListItem("tasks", {
-        from: activeIndex,
-        to: overIndex,
-      });
-    }
+    taskListForm.reorderListItem("tasks", {
+      from: activeIndex,
+      to: overIndex,
+    });
   };
 
   return (

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -3,6 +3,8 @@ import { UseFormReturnType } from "@mantine/form/lib/use-form";
 import { VFC } from "react";
 import { Task } from "../types/task";
 import { TaskItem } from "./TaskItem";
+import { DndContext, DragEndEvent } from "@dnd-kit/core";
+import { SortableContext } from "@dnd-kit/sortable";
 
 type TaskListProps = {
   tasks: Task[];
@@ -17,20 +19,45 @@ export const TaskList: VFC<TaskListProps> = ({
   taskListForm,
   handleSubmitToEditTask,
 }) => {
+  const handleDragEndToReorderTaskList = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (!over) return;
+
+    if (active.id !== over.id) {
+      const activeIndex = taskListForm.values.tasks.findIndex(
+        (task) => task.id === active.id
+      );
+
+      const overIndex = taskListForm.values.tasks.findIndex(
+        (task) => task.id === over.id
+      );
+
+      taskListForm.reorderListItem("tasks", {
+        from: activeIndex,
+        to: overIndex,
+      });
+    }
+  };
+
   return (
-    <ul>
-      {tasks.map((task, index) => (
-        <li key={task.id}>
-          <div className="py-2">
-            <TaskItem
-              task={task}
-              index={index}
-              taskListForm={taskListForm}
-              handleSubmitToEditTask={handleSubmitToEditTask}
-            />
-          </div>
-        </li>
-      ))}
-    </ul>
+    <DndContext onDragEnd={handleDragEndToReorderTaskList}>
+      <SortableContext items={tasks}>
+        <ul>
+          {tasks.map((task, index) => (
+            <li key={task.id}>
+              <div className="py-2">
+                <TaskItem
+                  task={task}
+                  index={index}
+                  taskListForm={taskListForm}
+                  handleSubmitToEditTask={handleSubmitToEditTask}
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+      </SortableContext>
+    </DndContext>
   );
 };

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,5 +1,5 @@
 export type Task = {
-  id: number;
+  id: string;
   content: string;
   isDone: boolean;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,6 +1174,11 @@
   dependencies:
     "@types/jest" "*"
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/websocket@^1.0.3":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.5.tgz#3fb80ed8e07f88e51961211cd3682a3a4a81569c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4531,6 +4531,11 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+tabler-icons-react@^1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/tabler-icons-react/-/tabler-icons-react-1.44.0.tgz#6536f524e03c765b78078e7f65d3539b946253b6"
+  integrity sha512-AYQQGl55yVe1KHZl+zyDAAwDOcPknKZNC7vgwmjyvpmz4P5Gjb7DtpsOPa1nB0qMYW5Orsrt+1e4qnRoCKgo6A==
+
 tailwindcss@^3.0.23:
   version "3.0.23"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.0.23.tgz#c620521d53a289650872a66adfcb4129d2200d10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,6 +322,37 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@dnd-kit/accessibility@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.0.0.tgz#b56e3750414fd907b7d6972b3116aa8f96d07fde"
+  integrity sha512-QwaQ1IJHQHMMuAGOOYHQSx7h7vMZPfO97aDts8t5N/MY7n2QTDSnW+kF7uRQ1tVBkr6vJ+BqHWG5dlgGvwVjow==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-5.0.3.tgz#028d7e543e9fd3756f9cb857b34f818d73020810"
+  integrity sha512-IribcBLsaPqHdYLpc5xG0TqwYIaD+65offdEYxoKh38WDjzRxUjDmrt7hj9oa/ooUKL0epux20u+mBTd92i/zw==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.0.0"
+    "@dnd-kit/utilities" "^3.1.0"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-6.0.1.tgz#08d046efa85c546fd21979836b007d6fea1001f9"
+  integrity sha512-FGpRHBcflpwWpSP8bMJ4zNcDywDXssZDJBwGYuHd1RqUU/+JX43pEU0u0OHw06LabEZMOLBbyWoIaZJ0abCOEA==
+  dependencies:
+    "@dnd-kit/utilities" "^3.1.0"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.1.0.tgz#330ef24303da05f85ff20bb8f74b385c96caee58"
+  integrity sha512-2JBdIgjJ7xjMRpKagdMuYKWJdDoVVw9Wc6lfMrLjrq8t4QlMEjtsab5JVUlzWvHgANn7w3Y3VhalFfbp4dQrKg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emotion/babel-plugin@^11.7.1":
   version "11.7.2"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz#fec75f38a6ab5b304b0601c74e2a5e77c95e5fa0"
@@ -4614,6 +4645,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.21.0:
   version "3.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4767,6 +4767,11 @@ util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"


### PR DESCRIPTION
# やったこと

- ドラッグ＆ドロップでタスクの並び替えを可能にしました。

# やらないこと

- TaskCardをまたいだタスクの並び替えの対応

# できるようになること

## ユーザ目線

- 同一の TaskCard（e.g. 今日する）においてタスクの並び替えが可能になる

## 開発目線

- 同上

# 動作確認

## タイトル

タスクの並び替え

### 何を

- 特定のタスクを別のタスク上にドラック＆ドロップするとお互いの順番が入れ替わる

### どのように

文面だと説明が難しいので、Videoをアップロードします。

### Screenshot / Video

https://user-images.githubusercontent.com/17216462/162172259-85249047-8f24-4d8b-9f9e-ace933e29552.mov


# レビュワーへの参考情報

## ドラッグ＆ドロップ

### グリップの実装
入れ替えに用いるグリップは以下のアイコンを採用しました。
Mantine の例でも使われているものです。

Tabler Icons for React
https://tabler-icons-react.vercel.app/

表示については↓が参考になるかと思います。

Tailwind group hover, the state you missed
https://daily-dev-tips.com/posts/tailwind-group-hover-the-state-you-missed/



### コア部分の実装
Mantine の例にある `react-beautiful-dnd` は今はもうメンテナンスされないライブラリなので採用せず、
`dnd-kit` の `Sortable` を用いてドラッグ＆ドロップを実装しました。

Sortable - dnd kit – Documentation
https://docs.dndkit.com/presets/sortable

mantine の例では `react-beautiful-dnd` を用いていますが、
実装の外観としては以下のソースが参考になるかと思います。

Drag'n'Drop | Mantine UI
https://ui.mantine.dev/category/dnd

use-form lists | Mantine
https://mantine.dev/form/lists/#list-items-reordering