### PR TITLE
バックエンド更新のため、タスクの各種操作でフォーム送信されるようにした

### DIFF
--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -37,6 +37,7 @@ export const TaskForm: VFC<Props> = ({ tasks, schedule }) => {
     taskListForm.addListItem("tasks", {
       ...task,
     });
+    console.table(task); // TODO: replace with backend query
 
     taskForm.reset();
   };
@@ -48,7 +49,7 @@ export const TaskForm: VFC<Props> = ({ tasks, schedule }) => {
   };
 
   const handleSubmitToEditTask = ({ tasks }: TaskListFormValues) => {
-    console.table(tasks);
+    console.table(tasks); // TODO: replace with backend query
   };
 
   return (

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -1,4 +1,4 @@
-import { VFC } from "react";
+import { useRef, VFC } from "react";
 import { Task } from "../types/task";
 import { TaskList } from "./TaskList";
 import Image from "next/image";
@@ -14,6 +14,8 @@ type Props = {
 };
 
 export const TaskForm: VFC<Props> = ({ tasks, schedule }) => {
+  const taskListFormSubmitButtonRef = useRef<HTMLButtonElement>(null);
+
   const taskListForm = useForm({
     initialValues: {
       tasks: formList<Task>(tasks),
@@ -39,6 +41,12 @@ export const TaskForm: VFC<Props> = ({ tasks, schedule }) => {
     taskForm.reset();
   };
 
+  const triggerTaskListFormSubmit = () => {
+    setTimeout(() => {
+      taskListFormSubmitButtonRef?.current?.click();
+    }, 500);
+  };
+
   const handleSubmitToEditTask = ({ tasks }: TaskListFormValues) => {
     console.table(tasks);
   };
@@ -50,9 +58,14 @@ export const TaskForm: VFC<Props> = ({ tasks, schedule }) => {
           tasks={taskListForm.values.tasks}
           schedule={schedule}
           taskListForm={taskListForm}
+          triggerTaskListFormSubmit={triggerTaskListFormSubmit}
           handleSubmitToEditTask={handleSubmitToEditTask}
         />
-        <button className="block invisible" />
+        <button
+          type="submit"
+          className="block invisible"
+          ref={taskListFormSubmitButtonRef}
+        />
       </form>
 
       <form onSubmit={taskForm.onSubmit(handleSubmitToAddTask)}>

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -49,6 +49,8 @@ export const TaskForm: VFC<Props> = ({ tasks, schedule }) => {
   };
 
   const handleSubmitToEditTask = ({ tasks }: TaskListFormValues) => {
+    if (!taskListForm.values.tasks.length) return;
+
     console.table(tasks); // TODO: replace with backend query
   };
 

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -18,6 +18,7 @@ type TaskItemProps = {
   taskListForm: UseFormReturnType<{
     tasks: FormList<Task>;
   }>;
+  triggerTaskListFormSubmit: () => void;
   handleSubmitToEditTask: ({ tasks }: { tasks: FormList<Task> }) => void;
 };
 
@@ -26,6 +27,7 @@ export const TaskItem: VFC<TaskItemProps> = ({
   schedule,
   index,
   taskListForm,
+  triggerTaskListFormSubmit,
   handleSubmitToEditTask,
 }) => {
   const handleClickToDuplicateTask: ComponentProps<"img">["onClick"] = () => {
@@ -36,10 +38,12 @@ export const TaskItem: VFC<TaskItemProps> = ({
       }),
       content: task.content,
     });
+    triggerTaskListFormSubmit();
   };
 
   const handleClickToDeleteTask: ComponentProps<"img">["onClick"] = () => {
     taskListForm.removeListItem("tasks", index);
+    triggerTaskListFormSubmit();
   };
 
   const { attributes, listeners, setNodeRef, transform, transition } =

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -34,10 +34,12 @@ export const TaskItem: VFC<TaskItemProps> = ({
     e
   ) => {
     const prevValue = taskListForm.values.tasks[index];
+    const isChecked = e.currentTarget.checked;
 
     taskListForm.setListItem("tasks", index, {
       ...prevValue,
-      isDone: e.currentTarget.checked,
+      isDone: isChecked,
+      done_at: isChecked ? new Date() : null,
     });
     triggerTaskListFormSubmit();
   };

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -30,6 +30,18 @@ export const TaskItem: VFC<TaskItemProps> = ({
   triggerTaskListFormSubmit,
   handleSubmitToEditTask,
 }) => {
+  const handleClickToToggleIsDone: ComponentProps<"input">["onChange"] = (
+    e
+  ) => {
+    const prevValue = taskListForm.values.tasks[index];
+
+    taskListForm.setListItem("tasks", index, {
+      ...prevValue,
+      isDone: e.currentTarget.checked,
+    });
+    triggerTaskListFormSubmit();
+  };
+
   const handleClickToDuplicateTask: ComponentProps<"img">["onClick"] = () => {
     taskListForm.addListItem("tasks", {
       ...initializedTask({
@@ -91,6 +103,8 @@ export const TaskItem: VFC<TaskItemProps> = ({
             {...taskListForm.getListInputProps("tasks", index, "isDone", {
               type: "checkbox",
             })}
+            checked={taskListForm.values.tasks[index].isDone}
+            onChange={handleClickToToggleIsDone}
           />
         </label>
       </div>

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -38,7 +38,7 @@ export const TaskItem: VFC<TaskItemProps> = ({
 
     taskListForm.setListItem("tasks", index, {
       ...prevValue,
-      isDone: isChecked,
+      is_done: isChecked,
       done_at: isChecked ? new Date() : null,
     });
     triggerTaskListFormSubmit();
@@ -88,7 +88,7 @@ export const TaskItem: VFC<TaskItemProps> = ({
           <div className="next-image-space-removal-wrapper">
             <Image
               src={`${
-                task.isDone
+                task.is_done
                   ? "/onCheckedCheckboxIcon.svg"
                   : "/offCheckedCheckboxIcon.svg"
               }`}
@@ -102,10 +102,10 @@ export const TaskItem: VFC<TaskItemProps> = ({
           <input
             className="absolute opacity-0"
             type="checkbox"
-            {...taskListForm.getListInputProps("tasks", index, "isDone", {
+            {...taskListForm.getListInputProps("tasks", index, "is_done", {
               type: "checkbox",
             })}
-            checked={taskListForm.values.tasks[index].isDone}
+            checked={taskListForm.values.tasks[index].is_done}
             onChange={handleClickToToggleIsDone}
           />
         </label>
@@ -113,7 +113,7 @@ export const TaskItem: VFC<TaskItemProps> = ({
 
       <input
         className={`w-full bg-transparent outline-none break-all ${
-          task.isDone ? "line-through text-[#C2C6D2]" : ""
+          task.is_done ? "line-through text-[#C2C6D2]" : ""
         }`}
         type="text"
         onBlur={taskListForm.onSubmit(handleSubmitToEditTask)}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -13,6 +13,7 @@ type TaskListProps = {
   taskListForm: UseFormReturnType<{
     tasks: FormList<Task>;
   }>;
+  triggerTaskListFormSubmit: () => void;
   handleSubmitToEditTask: ({ tasks }: { tasks: FormList<Task> }) => void;
 };
 
@@ -20,6 +21,7 @@ export const TaskList: VFC<TaskListProps> = ({
   tasks,
   schedule,
   taskListForm,
+  triggerTaskListFormSubmit,
   handleSubmitToEditTask,
 }) => {
   const handleDragEndToReorderTaskList = (event: DragEndEvent) => {
@@ -40,6 +42,8 @@ export const TaskList: VFC<TaskListProps> = ({
       from: activeIndex,
       to: overIndex,
     });
+
+    triggerTaskListFormSubmit();
   };
 
   return (
@@ -54,6 +58,7 @@ export const TaskList: VFC<TaskListProps> = ({
                   schedule={schedule}
                   index={index}
                   taskListForm={taskListForm}
+                  triggerTaskListFormSubmit={triggerTaskListFormSubmit}
                   handleSubmitToEditTask={handleSubmitToEditTask}
                 />
               </div>

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,8 +1,10 @@
 export type ScheduledDate = Date | null;
+type DoneAt = Date | null;
 
 export type Task = {
   id: string;
   content: string;
   scheduled_date: ScheduledDate;
   isDone: boolean;
+  done_at: DoneAt;
 };

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -5,6 +5,6 @@ export type Task = {
   id: string;
   content: string;
   scheduled_date: ScheduledDate;
-  isDone: boolean;
+  is_done: boolean;
   done_at: DoneAt;
 };

--- a/utils/initializedTask.ts
+++ b/utils/initializedTask.ts
@@ -4,5 +4,5 @@ export const initializedTask = ({
   id,
   scheduled_date,
 }: Pick<Task, "id" | "scheduled_date">): Task => {
-  return { id, content: "", scheduled_date, isDone: false };
+  return { id, content: "", scheduled_date, isDone: false, done_at: null };
 };

--- a/utils/initializedTask.ts
+++ b/utils/initializedTask.ts
@@ -4,5 +4,5 @@ export const initializedTask = ({
   id,
   scheduled_date,
 }: Pick<Task, "id" | "scheduled_date">): Task => {
-  return { id, content: "", scheduled_date, isDone: false, done_at: null };
+  return { id, content: "", scheduled_date, is_done: false, done_at: null };
 };


### PR DESCRIPTION
# やったこと

## 主目的
- タスクの各種操作でフォーム送信されるようにしました

## 追加対応
- 完了時に `done_at` が埋まるようにしました

# やらないこと

- このスコープの範囲外のこと

# できるようになること

## ユーザ目線

- とくになし

## 開発目線

- フロントエンドの状態変化をキーにフォーム送信することで、状態変化をバックエンドに反映することができるようになる

# 動作確認

## タイトル

タスク操作でフォーム送信

### 何を

以下のタスク操作でフォーム送信が実行されることを確認

- 追加
- 複製
- 削除
- 完了・未完了の切り替え

### どのように

フォーム送信時に `console.table` でフォームの状態を表示するデバッグログを仕込んでいます。
そのため、コンソールを開き、各種操作をした際にその状態がコンソールに表示されることを確認します。

### Screenshot / Video

https://user-images.githubusercontent.com/17216462/162937992-321fedc1-0f9d-4d3f-9209-5d9bacd0d1f1.mov

# レビュワーへの参考情報

-
