### PR TITLE
タスクを作成可能にするために、ログイン後にユーザのプロフィールを仮登録するようにした

### DIFF
--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, VFC } from "react";
+import { VFC } from "react";
 import { TaskCard } from "../TaskCard";
 import { ScheduleType, SCHEDULE_LIST } from "../TaskHeader";
 import { Task } from "../../types/task";

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -1,9 +1,67 @@
-import type { VFC } from "react";
+import { useEffect, useState, VFC } from "react";
 import { TaskCard } from "../TaskCard";
 import { ScheduleType, SCHEDULE_LIST } from "../TaskHeader";
 import { Task } from "../../types/task";
+import { Loader } from "../Loader";
+import { Auth } from "@supabase/ui";
+import { supabase } from "../../../utils/supabaseClient";
+import { User } from "@supabase/gotrue-js";
+import useFetchUser from "../../hooks/useFetchUser";
+
+const findOrCreateProfile = async (user: User) => {
+  const { data, count } = await findProfile();
+
+  if (count) return data;
+
+  return await createProfile(user);
+};
+
+const findProfile = async () => {
+  const { data, error, count } = await supabase
+    .from("profiles")
+    .select("*", { count: "exact" });
+
+  if (error) throw error;
+
+  return { data, count };
+};
+
+const createProfile = async (user: User) => {
+  const { data, error } = await supabase
+    .from("profiles")
+    .insert([{ id: user.id, name: user.user_metadata?.name || "unknown" }]);
+
+  if (error) throw error;
+
+  return data;
+};
 
 export const Main: VFC = () => {
+  const { session } = Auth.useUser();
+  const { user, error, isLoading } = useFetchUser(session);
+  const [profile, setProfile] = useState<any[] | null>(null);
+
+  useEffect(() => {
+    if (user) {
+      findOrCreateProfile(user)
+        .then((profile) => {
+          setProfile(profile);
+          console.table(profile);
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    }
+  }, [user]);
+
+  if (error) {
+    return <Loader />; // TODO: should be replaced with `Error Boundary`
+  }
+
+  if (isLoading || !user || !profile) {
+    return <Loader />;
+  }
+
   const myTasks: Task[] = [];
 
   const filterTasksBySchedule = (myTasks: Task[], schedule: ScheduleType) => {

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -1,64 +1,34 @@
-import { useEffect, useState, VFC } from "react";
+import { useEffect, VFC } from "react";
 import { TaskCard } from "../TaskCard";
 import { ScheduleType, SCHEDULE_LIST } from "../TaskHeader";
 import { Task } from "../../types/task";
 import { Loader } from "../Loader";
 import { Auth } from "@supabase/ui";
-import { supabase } from "../../../utils/supabaseClient";
-import { User } from "@supabase/gotrue-js";
 import useFetchUser from "../../hooks/useFetchUser";
-
-const findOrCreateProfile = async (user: User) => {
-  const { data, count } = await findProfile();
-
-  if (count) return data;
-
-  return await createProfile(user);
-};
-
-const findProfile = async () => {
-  const { data, error, count } = await supabase
-    .from("profiles")
-    .select("*", { count: "exact" });
-
-  if (error) throw error;
-
-  return { data, count };
-};
-
-const createProfile = async (user: User) => {
-  const { data, error } = await supabase
-    .from("profiles")
-    .insert([{ id: user.id, name: user.user_metadata?.name || "unknown" }]);
-
-  if (error) throw error;
-
-  return data;
-};
+import useFetchOrCreateProfile from "../../hooks/useFetchOrCreateProfile";
 
 export const Main: VFC = () => {
   const { session } = Auth.useUser();
-  const { user, error, isLoading } = useFetchUser(session);
-  const [profile, setProfile] = useState<any[] | null>(null);
+  const {
+    user,
+    error: userError,
+    isLoading: userLoading,
+  } = useFetchUser(session);
+  const {
+    profile,
+    error: profileError,
+    isLoading: profileLoading,
+  } = useFetchOrCreateProfile(user);
 
-  useEffect(() => {
-    if (user) {
-      findOrCreateProfile(user)
-        .then((profile) => {
-          setProfile(profile);
-          console.table(profile);
-        })
-        .catch((error) => {
-          console.error(error);
-        });
-    }
-  }, [user]);
-
-  if (error) {
+  if (userError || profileError) {
     return <Loader />; // TODO: should be replaced with `Error Boundary`
   }
 
-  if (isLoading || !user || !profile) {
+  if (userLoading || profileLoading) {
+    return <Loader />;
+  }
+
+  if (!user || !profile) {
     return <Loader />;
   }
 

--- a/src/hooks/useFetchOrCreateProfile.ts
+++ b/src/hooks/useFetchOrCreateProfile.ts
@@ -44,8 +44,8 @@ const useFetchOrCreateProfile = (user: User | null) => {
         .then((profile) => {
           setProfile(profile);
         })
-        .catch((error) => {
-          console.error(error);
+        .catch((error: PostgrestError) => {
+          console.error(error.message, error.code, error.details, error.hint);
           setError(error);
         })
         .finally(() => {

--- a/src/hooks/useFetchOrCreateProfile.ts
+++ b/src/hooks/useFetchOrCreateProfile.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { User } from "@supabase/gotrue-js";
+import { supabase } from "../../utils/supabaseClient";
+import { PostgrestError } from "@supabase/supabase-js";
+
+const findOrCreateProfile = async (user: User) => {
+  const { data, count } = await findProfile();
+
+  if (count) return data;
+
+  return await createProfile(user);
+};
+
+const findProfile = async () => {
+  const { data, error, count } = await supabase
+    .from("profiles")
+    .select("*", { count: "exact" });
+
+  if (error) throw error;
+
+  return { data, count };
+};
+
+const createProfile = async (user: User) => {
+  const { data, error } = await supabase
+    .from("profiles")
+    .insert([{ id: user.id, name: user.user_metadata?.name || "unknown" }]);
+
+  if (error) throw error;
+
+  return data;
+};
+
+const useFetchOrCreateProfile = (user: User | null) => {
+  const [profile, setProfile] = useState<any[] | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<PostgrestError | null>(null);
+
+  useEffect(() => {
+    if (user) {
+      setIsLoading(true);
+
+      findOrCreateProfile(user)
+        .then((profile) => {
+          setProfile(profile);
+          console.table(profile);
+        })
+        .catch((error) => {
+          console.error(error);
+          setError(error);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+  }, [user]);
+
+  return { profile, error, isLoading };
+};
+
+export default useFetchOrCreateProfile;

--- a/src/hooks/useFetchOrCreateProfile.ts
+++ b/src/hooks/useFetchOrCreateProfile.ts
@@ -3,15 +3,15 @@ import { User } from "@supabase/gotrue-js";
 import { supabase } from "../../utils/supabaseClient";
 import { PostgrestError } from "@supabase/supabase-js";
 
-const findOrCreateProfile = async (user: User) => {
-  const { data, count } = await findProfile();
+const fetchOrCreateProfile = async (user: User) => {
+  const { data, count } = await fetchProfile();
 
   if (count) return data;
 
   return await createProfile(user);
 };
 
-const findProfile = async () => {
+const fetchProfile = async () => {
   const { data, error, count } = await supabase
     .from("profiles")
     .select("*", { count: "exact" });
@@ -40,7 +40,7 @@ const useFetchOrCreateProfile = (user: User | null) => {
     if (user) {
       setIsLoading(true);
 
-      findOrCreateProfile(user)
+      fetchOrCreateProfile(user)
         .then((profile) => {
           setProfile(profile);
           console.table(profile);

--- a/src/hooks/useFetchOrCreateProfile.ts
+++ b/src/hooks/useFetchOrCreateProfile.ts
@@ -43,7 +43,6 @@ const useFetchOrCreateProfile = (user: User | null) => {
       fetchOrCreateProfile(user)
         .then((profile) => {
           setProfile(profile);
-          console.table(profile);
         })
         .catch((error) => {
           console.error(error);

--- a/src/hooks/useFetchUser.ts
+++ b/src/hooks/useFetchUser.ts
@@ -23,7 +23,7 @@ const useFetchUser = (session: Session | null) => {
         .then((user) => {
           setUser(user);
         })
-        .catch((error) => {
+        .catch((error: ApiError) => {
           setError(error);
           console.error(error.message, error.status);
         })

--- a/src/hooks/useFetchUser.ts
+++ b/src/hooks/useFetchUser.ts
@@ -2,29 +2,34 @@ import { useEffect, useState } from "react";
 import { Session, User, ApiError } from "@supabase/gotrue-js";
 import { supabase } from "../../utils/supabaseClient";
 
+const fetchUserBySession = async (session: Session) => {
+  const { user, error } = await supabase.auth.api.getUser(session.access_token);
+
+  if (error) throw error;
+
+  return user;
+};
+
 const useFetchUser = (session: Session | null) => {
   const [user, setUser] = useState<User | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<ApiError | null>(null);
-
-  const fetchUserBySession = async (session: Session) => {
-    const { user, error } = await supabase.auth.api.getUser(
-      session.access_token
-    );
-    if (error) {
-      setError(error);
-      console.error(error.message, error.status);
-    }
-    if (user) setUser(user);
-
-    setIsLoading(false);
-  };
 
   useEffect(() => {
     if (session) {
-      fetchUserBySession(session);
-    } else {
-      setIsLoading(false);
+      setIsLoading(true);
+
+      fetchUserBySession(session)
+        .then((user) => {
+          setUser(user);
+        })
+        .catch((error) => {
+          setError(error);
+          console.error(error.message, error.status);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
     }
   }, [session]);
 


### PR DESCRIPTION
# やったこと

- ログイン後にユーザのプロフィールを仮登録するようにしました。
	- プロフィールの情報は Google でログインを前提とした情報が入ります。

# やらないこと

- このスコープの範囲外のこと

# できるようになること

## ユーザ目線

- 特になし

## 開発目線

- プロフィール設定で初期値を事前に表示できる
- ログインユーザの関連する task テーブルへのCRUD操作が可能になる
	- FYI:
		- Profile -> Task という関連があるため、事前にプロフィールを作成しておく必要があります。

# 動作確認

## タイトル

ログイン後、バックエンドにプロフィールが作成される

### 何を

- ログイン後
	- プロフィール未作成のとき
		- バックエンドにログインしたプロフィールが作成される
	- プロフィール作成済みのとき
		- バックエンドからプロフィール情報を取得する。
		- （プロフィール情報を取得して何もしない）

### どのように

#### プロフィール未作成のとき
- 事前にバックエンドの profile を空にしておく
- Google でログインする
- profile レコードが作成されていることを確認

#### プロフィール作成済みのとき
- 上記の手順で事前にバックエンドの profile を作成しておく
- ログアウトする
- Google でログインする
- profile レコードが重複作成されないことを確認
- メインコンテンツが表示されることを確認（＝プロフィール情報が取得できていることと同義です）

#### FYI
↓にて `profile` テーブルの閲覧・編集が可能です。
https://app.supabase.io/project/ikgbrzzcdnnfwwqcpbwz/editor/16725

雑に作成したり削除してもらったりしてかまわないです 🙆‍♂️ 

### Screenshot / Video

#### 作成されたプロフィール
<img width="1356" alt="スクリーンショット 2022-04-16 0 23 26" src="https://user-images.githubusercontent.com/17216462/163589164-d0c62325-cae6-49c4-9a45-f71c5f3493b9.png">


# レビュワーへの参考情報
## テーブルの関連
backend-designs-for-qin-todo
https://gist.github.com/Natch/e738358f1a56b78f1b49cfc92569c496

## クエリのAPI
Create data: insert() | Supabase
https://supabase.com/docs/reference/javascript/insert

Fetch data: select() | Supabase
https://supabase.com/docs/reference/javascript/select